### PR TITLE
Enhancements - start testing logger

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+issues:
+  exclude-rules:
+    # b/c S1005 yields a bad result
+    - linters:
+      - gosimple
+      text: "S1005:"
+    # b/c S1033 yields a bad result
+    - linters:
+      - gosimple
+      text: "S1033:"

--- a/formatter/jsonFormatter.go
+++ b/formatter/jsonFormatter.go
@@ -57,7 +57,7 @@ func (ljf *logJsonFormatter) Format(r interfaces.Record) []byte {
 	}
 
 	// TODO: replace the JSON parser
-	jsonByteData, err := json.Marshal(jsonAttributes)
+	jsonByteData, _ := json.Marshal(jsonAttributes)
 	r.CacheFormat(ljf.name, jsonByteData)
 	return jsonByteData
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -90,7 +90,7 @@ func (lh *logHandler) Handle(r interfaces.Record) {
 		formattedOutput = []byte(
 			fmt.Sprintf(
 				r.RawMessage(),
-				r.RawMessageArgs(),
+				r.RawMessageArgs()...,
 			),
 		)
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -192,7 +192,7 @@ func TestHandler(t *testing.T) {
 					lh.SetFormatter(nil)
 
 					lr := internal.NewMockRecord()
-					lr.MockRawMessage = "raw formatter - %#v"
+					lr.MockRawMessage = "raw formatter - %s %s %s"
 					lr.MockRawMessageArgs = []any{
 						"raw",
 						"message",
@@ -200,7 +200,7 @@ func TestHandler(t *testing.T) {
 					}
 
 					lh.Handle(lr)
-					expectedOutput := "raw formatter - []interface {}{\"raw\", \"message\", \"args\"}"
+					expectedOutput := "raw formatter - raw message args"
 					out := lhOutput.String()
 					if out != expectedOutput {
 						t.Errorf("Unexpected output received: %q != %q", out, expectedOutput)

--- a/interfaces/logger.go
+++ b/interfaces/logger.go
@@ -2,12 +2,18 @@ package interfaces
 
 type Log interface {
 	Name() string
-	Info(format string, v ...any)
-	Warning(format string, v ...any)
-	Debug(format string, v ...any)
-	Error(format string, v ...any)
-	Critical(format string, v ...any)
-	Log(l Level, format string, v ...any)
+	Info(msg string)
+	Infof(format string, v ...any)
+	Warning(msg string)
+	Warningf(format string, v ...any)
+	Debug(msg string)
+	Debugf(format string, v ...any)
+	Error(msg string)
+	Errorf(format string, v ...any)
+	Critical(msg string)
+	Criticalf(format string, v ...any)
+	Log(l Level, msg string)
+	Logf(l Level, format string, v ...any)
 
 	ProcessRecord(r Record)
 	AddHandler(h Handler)

--- a/internal/mockHandler.go
+++ b/internal/mockHandler.go
@@ -1,0 +1,90 @@
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/ClockwerksSoftware/golog/interfaces"
+)
+
+type MockHandler struct {
+	name         string
+	children  []interfaces.Handler
+	filters   []interfaces.Filter
+	formatter interfaces.Formatter
+	writer    io.Writer
+	Buffer    *bytes.Buffer
+}
+
+func NewMockHandler(name string) *MockHandler {
+	mh := &MockHandler{
+		name: name,
+		children: make([]interfaces.Handler, 0),
+		filters: make([]interfaces.Filter, 0),
+		formatter: nil,
+		Buffer: &bytes.Buffer{},
+	}
+	mh.writer = mh.Buffer
+	return mh
+}
+
+func (mh *MockHandler) Name() string {
+	return mh.name
+}
+func (mh *MockHandler) ChildHandlers() []interfaces.Handler {
+	return mh.children
+}
+func (mh *MockHandler) AddChildHandler(h interfaces.Handler) {
+	mh.children = append(mh.children, h)
+}
+func (mh *MockHandler) Filters() []interfaces.Filter {
+	return mh.filters
+}
+func (mh *MockHandler) AddFilter(f interfaces.Filter) {
+	mh.filters = append(mh.filters, f)
+}
+func (mh *MockHandler) Formatter() interfaces.Formatter {
+	return mh.formatter
+}
+func (mh *MockHandler) SetFormatter(f interfaces.Formatter) {
+	mh.formatter = f
+}
+func (mh *MockHandler) Output() io.Writer {
+	return mh.writer
+}
+func (mh *MockHandler) SetOutput(w io.Writer) {
+	mh.writer = w
+}
+func (mh *MockHandler) Handle(r interfaces.Record) {
+	if r == nil {
+		return
+	}
+
+	for _, filter := range mh.filters {
+		if _, ok := filter.Filter(r); !ok {
+			return
+		}
+	}
+
+	var formattedOutput []byte
+	if mh.formatter != nil {
+		formattedOutput = mh.formatter.Format(r)
+	} else {
+		formattedOutput = []byte(
+			fmt.Sprintf(
+				r.RawMessage(),
+				r.RawMessageArgs()...,
+			),
+		)
+	}
+
+	if mh.writer != nil {
+		_, _ = mh.writer.Write(formattedOutput)
+	}
+	for _, handler := range mh.children {
+		handler.Handle(r)
+	}
+}
+
+var _ interfaces.Handler = &MockHandler{}

--- a/loggers/child.go
+++ b/loggers/child.go
@@ -24,28 +24,52 @@ func NewChildLogger(name string, root interfaces.Log) interfaces.Log {
 func (cl *childLogger) Name() string {
 	return cl.name
 }
-func (cl *childLogger) Info(msg string, args ...any) {
-	r := record.NewLogRecord(cl.name, record.INFO, msg, args...)
+func (cl *childLogger) Info(msg string) {
+	r := record.NewLogRecord(cl.name, record.INFO, msg)
 	cl.sendRecord(r)
 }
-func (cl *childLogger) Warning(msg string, args ...any) {
-	r := record.NewLogRecord(cl.name, record.WARNING, msg, args...)
+func (cl *childLogger) Infof(format string, args ...any) {
+	r := record.NewLogRecord(cl.name, record.INFO, format, args...)
 	cl.sendRecord(r)
 }
-func (cl *childLogger) Error(msg string, args ...any) {
-	r := record.NewLogRecord(cl.name, record.ERROR, msg, args...)
+func (cl *childLogger) Warning(msg string) {
+	r := record.NewLogRecord(cl.name, record.WARNING, msg)
 	cl.sendRecord(r)
 }
-func (cl *childLogger) Debug(msg string, args ...any) {
-	r := record.NewLogRecord(cl.name, record.DEBUG, msg, args...)
+func (cl *childLogger) Warningf(format string, args ...any) {
+	r := record.NewLogRecord(cl.name, record.WARNING, format, args...)
 	cl.sendRecord(r)
 }
-func (cl *childLogger) Critical(msg string, args ...any) {
-	r := record.NewLogRecord(cl.name, record.CRITICAL, msg, args...)
+func (cl *childLogger) Error(msg string) {
+	r := record.NewLogRecord(cl.name, record.ERROR, msg)
 	cl.sendRecord(r)
 }
-func (cl *childLogger) Log(l interfaces.Level, msg string, args ...any) {
-	r := record.NewLogRecord(cl.name, record.LogLevelInt(l.Int()), msg, args...)
+func (cl *childLogger) Errorf(format string, args ...any) {
+	r := record.NewLogRecord(cl.name, record.ERROR, format, args...)
+	cl.sendRecord(r)
+}
+func (cl *childLogger) Debug(msg string) {
+	r := record.NewLogRecord(cl.name, record.DEBUG, msg)
+	cl.sendRecord(r)
+}
+func (cl *childLogger) Debugf(format string, args ...any) {
+	r := record.NewLogRecord(cl.name, record.DEBUG, format, args...)
+	cl.sendRecord(r)
+}
+func (cl *childLogger) Critical(msg string) {
+	r := record.NewLogRecord(cl.name, record.CRITICAL, msg)
+	cl.sendRecord(r)
+}
+func (cl *childLogger) Criticalf(format string, args ...any) {
+	r := record.NewLogRecord(cl.name, record.CRITICAL, format, args...)
+	cl.sendRecord(r)
+}
+func (cl *childLogger) Log(l interfaces.Level, msg string) {
+	r := record.NewLogRecord(cl.name, record.LogLevelInt(l.Int()), msg)
+	cl.sendRecord(r)
+}
+func (cl *childLogger) Logf(l interfaces.Level, format string, args ...any) {
+	r := record.NewLogRecord(cl.name, record.LogLevelInt(l.Int()), format, args...)
 	cl.sendRecord(r)
 }
 

--- a/loggers/child_test.go
+++ b/loggers/child_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ClockwerksSoftware/golog/record"
 )
 
-func TestCoreLogger(t *testing.T) {
+func TestChildLogger(t *testing.T) {
 	t.Run(
 		"construct",
 		func(t *testing.T) {
@@ -19,15 +19,13 @@ func TestCoreLogger(t *testing.T) {
 				handlers: make([]interfaces.Handler, 0),
 				childLoggers: make(map[string]interfaces.Log),
 			}
+			ccl := NewChildLogger(expectedName, cl).(*childLogger)
 
-			if cl.Name() != expectedName {
+			if ccl.Name() != expectedName {
 				t.Errorf("Unexpected `name` received: %q != %q", cl.Name(), expectedName)
 			}
-			if len(cl.handlers) != 0 {
-				t.Errorf("Unexpected handlers found: %#v", cl.handlers)
-			}
-			if len(cl.childLoggers) != 0 {
-				t.Errorf("Unexpected child loggers found: %#v", cl.childLoggers)
+			if ccl.root != cl {
+				t.Errorf("Unexpected root found: %#v != %#v", ccl.root, cl)
 			}
 		},
 	)
@@ -36,7 +34,7 @@ func TestCoreLogger(t *testing.T) {
 		func(t *testing.T) {
 			type TestScenarioParameters struct {
 				beginFn func(t *testing.T)
-				doFn func(t *testing.T, cl *coreLogger)
+				doFn func(t *testing.T, cl *childLogger)
 				expectFn func(t *testing.T, output string)
 			}
 			type TestScenario struct {
@@ -50,7 +48,7 @@ func TestCoreLogger(t *testing.T) {
 						msg := "some message"
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Info(msg)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -69,7 +67,7 @@ func TestCoreLogger(t *testing.T) {
 						expectedMsg := fmt.Sprintf(msg, args...)
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Infof(msg, args...)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -86,7 +84,7 @@ func TestCoreLogger(t *testing.T) {
 						msg := "warn some message"
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Warning(msg)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -105,7 +103,7 @@ func TestCoreLogger(t *testing.T) {
 						expectedMsg := fmt.Sprintf(msg, args...)
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Warningf(msg, args...)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -122,7 +120,7 @@ func TestCoreLogger(t *testing.T) {
 						msg := "error some message"
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Error(msg)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -141,7 +139,7 @@ func TestCoreLogger(t *testing.T) {
 						expectedMsg := fmt.Sprintf(msg, args...)
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Errorf(msg, args...)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -158,7 +156,7 @@ func TestCoreLogger(t *testing.T) {
 						msg := "debug some message"
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Debug(msg)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -177,7 +175,7 @@ func TestCoreLogger(t *testing.T) {
 						expectedMsg := fmt.Sprintf(msg, args...)
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Debugf(msg, args...)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -194,7 +192,7 @@ func TestCoreLogger(t *testing.T) {
 						msg := "critical some message"
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Critical(msg)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -213,7 +211,7 @@ func TestCoreLogger(t *testing.T) {
 						expectedMsg := fmt.Sprintf(msg, args...)
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Criticalf(msg, args...)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -230,7 +228,7 @@ func TestCoreLogger(t *testing.T) {
 						msg := "log some message"
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Log(record.GetLogLevel(record.DEBUG), msg)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -249,7 +247,7 @@ func TestCoreLogger(t *testing.T) {
 						expectedMsg := fmt.Sprintf(msg, args...)
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								cl.Logf(record.GetLogLevel(record.ERROR), msg, args...)
 							},
 							expectFn: func(t *testing.T, output string) {
@@ -268,7 +266,7 @@ func TestCoreLogger(t *testing.T) {
 						expectedMsg := fmt.Sprintf(msg, args...)
 						return TestScenarioParameters{
 							beginFn: func(t *testing.T) {},
-							doFn: func(t *testing.T, cl *coreLogger) {
+							doFn: func(t *testing.T, cl *childLogger) {
 								r := record.NewLogRecord("foo", record.DEBUG, msg, args...)
 								cl.ProcessRecord(r)
 							},
@@ -292,16 +290,36 @@ func TestCoreLogger(t *testing.T) {
 							handlers: make([]interfaces.Handler, 0),
 							childLoggers: make(map[string]interfaces.Log),
 						}
+						ccl := NewChildLogger(t.Name(), cl).(*childLogger)
 						mh := internal.NewMockHandler(t.Name())
 						cl.AddHandler(mh)
 
 						parameters := scenario.setupFn(t)
 
 						parameters.beginFn(t)
-						parameters.doFn(t, cl)
+						parameters.doFn(t, ccl)
 						parameters.expectFn(t, mh.Buffer.String())
 					},
 				)
+			}
+		},
+	)
+	t.Run(
+		"addHandler",
+		func(t *testing.T) {
+			cl := &coreLogger{
+				name:  t.Name(),
+				handlers: make([]interfaces.Handler, 0),
+				childLoggers: make(map[string]interfaces.Log),
+			}
+			ccl := NewChildLogger(t.Name(), cl).(*childLogger)
+			mh := internal.NewMockHandler(t.Name())
+			if len(cl.handlers) != 0 {
+				t.Errorf("Unexpected handler found: %#v", cl.handlers)
+			}
+			ccl.AddHandler(mh)
+			if len(cl.handlers) != 1 {
+				t.Errorf("Unexpected handlers found: (len != 1) - %#v", cl.handlers)
 			}
 		},
 	)

--- a/loggers/core.go
+++ b/loggers/core.go
@@ -16,28 +16,52 @@ type coreLogger struct {
 func (lc *coreLogger) Name() string {
 	return lc.name
 }
-func (lc *coreLogger) Info(msg string, args ...any) {
-	r := record.NewLogRecord(rootLoggerName, record.INFO, msg, args...)
+func (lc *coreLogger) Info(msg string) {
+	r := record.NewLogRecord(rootLoggerName, record.INFO, msg)
 	lc.sendRecord(r)
 }
-func (lc *coreLogger) Warning(msg string, args ...any) {
-	r := record.NewLogRecord(rootLoggerName, record.WARNING, msg, args...)
+func (lc *coreLogger) Infof(format string, args ...any) {
+	r := record.NewLogRecord(rootLoggerName, record.INFO, format, args...)
 	lc.sendRecord(r)
 }
-func (lc *coreLogger) Error(msg string, args ...any) {
-	r := record.NewLogRecord(rootLoggerName, record.ERROR, msg, args...)
+func (lc *coreLogger) Warning(msg string) {
+	r := record.NewLogRecord(rootLoggerName, record.WARNING, msg)
 	lc.sendRecord(r)
 }
-func (lc *coreLogger) Debug(msg string, args ...any) {
-	r := record.NewLogRecord(rootLoggerName, record.DEBUG, msg, args...)
+func (lc *coreLogger) Warningf(format string, args ...any) {
+	r := record.NewLogRecord(rootLoggerName, record.WARNING, format, args...)
 	lc.sendRecord(r)
 }
-func (lc *coreLogger) Critical(msg string, args ...any) {
-	r := record.NewLogRecord(rootLoggerName, record.CRITICAL, msg, args...)
+func (lc *coreLogger) Error(msg string) {
+	r := record.NewLogRecord(rootLoggerName, record.ERROR, msg)
 	lc.sendRecord(r)
 }
-func (lc *coreLogger) Log(l interfaces.Level, msg string, args ...any) {
-	r := record.NewLogRecord(rootLoggerName, record.LogLevelInt(l.Int()), msg, args...)
+func (lc *coreLogger) Errorf(format string, args ...any) {
+	r := record.NewLogRecord(rootLoggerName, record.ERROR, format, args...)
+	lc.sendRecord(r)
+}
+func (lc *coreLogger) Debug(msg string) {
+	r := record.NewLogRecord(rootLoggerName, record.DEBUG, msg)
+	lc.sendRecord(r)
+}
+func (lc *coreLogger) Debugf(format string, args ...any) {
+	r := record.NewLogRecord(rootLoggerName, record.DEBUG, format, args...)
+	lc.sendRecord(r)
+}
+func (lc *coreLogger) Critical(msg string) {
+	r := record.NewLogRecord(rootLoggerName, record.CRITICAL, msg)
+	lc.sendRecord(r)
+}
+func (lc *coreLogger) Criticalf(format string, args ...any) {
+	r := record.NewLogRecord(rootLoggerName, record.CRITICAL, format, args...)
+	lc.sendRecord(r)
+}
+func (lc *coreLogger) Log(l interfaces.Level, msg string) {
+	r := record.NewLogRecord(rootLoggerName, record.LogLevelInt(l.Int()), msg)
+	lc.sendRecord(r)
+}
+func (lc *coreLogger) Logf(l interfaces.Level, format string, args ...any) {
+	r := record.NewLogRecord(rootLoggerName, record.LogLevelInt(l.Int()), format, args...)
 	lc.sendRecord(r)
 }
 

--- a/loggers/core_test.go
+++ b/loggers/core_test.go
@@ -1,0 +1,315 @@
+package loggers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ClockwerksSoftware/golog/interfaces"
+	"github.com/ClockwerksSoftware/golog/internal"
+	"github.com/ClockwerksSoftware/golog/record"
+)
+
+
+
+func TestCoreLogger(t *testing.T) {
+	t.Run(
+		"construct",
+		func(t *testing.T) {
+			expectedName := "foo"
+			cl := &coreLogger{
+				name: expectedName,
+				handlers: make([]interfaces.Handler, 0),
+				childLoggers: make(map[string]interfaces.Log),
+			}
+
+			if cl.Name() != expectedName {
+				t.Errorf("Unexpected `name` received: %q != %q", cl.Name(), expectedName)
+			}
+			if len(cl.handlers) != 0 {
+				t.Errorf("Unexpected handlers found: %#v", cl.handlers)
+			}
+			if len(cl.childLoggers) != 0 {
+				t.Errorf("Unexpected child loggers found: %#v", cl.childLoggers)
+			}
+		},
+	)
+	t.Run(
+		"logCalls",
+		func(t *testing.T) {
+			t.Run(
+				"unformatted",
+				func(t *testing.T) {
+					type TestScenarioParameters struct {
+						beginFn func(t *testing.T)
+						doFn func(t *testing.T, cl *coreLogger)
+						expectFn func(t *testing.T, output string)
+					}
+					type TestScenario struct {
+						name string
+						setupFn func(t *testing.T) TestScenarioParameters
+					}
+					TestScenarios := []TestScenario{
+						{
+							name: "Info",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "some message"
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Info(msg)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != msg {
+											t.Errorf("Unexpected result: %q != %q", output, msg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Infof",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "some message - %s, %d"
+								args := []any{"foo", 100}
+								expectedMsg := fmt.Sprintf(msg, args...)
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Infof(msg, args...)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != expectedMsg {
+											t.Errorf("Unexpected result: %q != %q", output, expectedMsg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Warning",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "warn some message"
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Warning(msg)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != msg {
+											t.Errorf("Unexpected result: %q != %q", output, msg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Warningf",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "warn some message - %s, %d"
+								args := []any{"foo", 100}
+								expectedMsg := fmt.Sprintf(msg, args...)
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Warningf(msg, args...)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != expectedMsg {
+											t.Errorf("Unexpected result: %q != %q", output, expectedMsg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Error",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "error some message"
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Error(msg)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != msg {
+											t.Errorf("Unexpected result: %q != %q", output, msg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Errorf",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "error some message - %s, %d"
+								args := []any{"foo", 100}
+								expectedMsg := fmt.Sprintf(msg, args...)
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Errorf(msg, args...)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != expectedMsg {
+											t.Errorf("Unexpected result: %q != %q", output, expectedMsg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Debug",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "debug some message"
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Debug(msg)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != msg {
+											t.Errorf("Unexpected result: %q != %q", output, msg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Debugf",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "debug some message - %s, %d"
+								args := []any{"foo", 100}
+								expectedMsg := fmt.Sprintf(msg, args...)
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Debugf(msg, args...)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != expectedMsg {
+											t.Errorf("Unexpected result: %q != %q", output, expectedMsg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Critical",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "critical some message"
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Critical(msg)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != msg {
+											t.Errorf("Unexpected result: %q != %q", output, msg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Criticalf",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "critical some message - %s, %d"
+								args := []any{"foo", 100}
+								expectedMsg := fmt.Sprintf(msg, args...)
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Criticalf(msg, args...)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != expectedMsg {
+											t.Errorf("Unexpected result: %q != %q", output, expectedMsg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Log",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "log some message"
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Log(record.GetLogLevel(record.DEBUG), msg)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != msg {
+											t.Errorf("Unexpected result: %q != %q", output, msg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "Logf",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "log some message - %s, %d"
+								args := []any{"foo", 100}
+								expectedMsg := fmt.Sprintf(msg, args...)
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										cl.Logf(record.GetLogLevel(record.ERROR), msg, args...)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != expectedMsg {
+											t.Errorf("Unexpected result: %q != %q", output, expectedMsg)
+										}
+									},
+								}
+							},
+						},
+						{
+							name: "ProcessRecord",
+							setupFn: func(t *testing.T) TestScenarioParameters {
+								msg := "log some message - %s, %d"
+								args := []any{"foo", 100}
+								expectedMsg := fmt.Sprintf(msg, args...)
+								return TestScenarioParameters{
+									beginFn: func(t *testing.T) {},
+									doFn: func(t *testing.T, cl *coreLogger) {
+										r := record.NewLogRecord("foo", record.DEBUG, msg, args...)
+										cl.ProcessRecord(r)
+									},
+									expectFn: func(t *testing.T, output string) {
+										if output != expectedMsg {
+											t.Errorf("Unexpected result: %q != %q", output, expectedMsg)
+										}
+									},
+								}
+							},
+						},
+					}
+
+					for _, scenario := range TestScenarios {
+						scenario := scenario
+						t.Run(
+							scenario.name,
+							func(t *testing.T) {
+								cl := &coreLogger{
+									name:  t.Name(),
+									handlers: make([]interfaces.Handler, 0),
+									childLoggers: make(map[string]interfaces.Log),
+								}
+								mh := internal.NewMockHandler(t.Name())
+								cl.AddHandler(mh)
+
+								parameters := scenario.setupFn(t)
+
+								parameters.beginFn(t)
+								parameters.doFn(t, cl)
+								parameters.expectFn(t, mh.Buffer.String())
+							},
+						)
+					}
+				},
+			)
+		},
+	)
+}

--- a/loggers/init.go
+++ b/loggers/init.go
@@ -1,6 +1,10 @@
 package loggers
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/ClockwerksSoftware/golog/handler"
 	"github.com/ClockwerksSoftware/golog/interfaces"
 )
 
@@ -19,8 +23,22 @@ func init() {
 		handlers:     make([]interfaces.Handler, 0),
 		childLoggers: make(map[string]interfaces.Log),
 	}
+	if defaultHandler := handler.New(); defaultHandler != nil {
+		root.AddHandler(defaultHandler)
+	} else {
+		fmt.Fprintf(os.Stderr, "**********************************\nFailed to allocate default handler\n**********************************\n")
+	}
 }
 
+// DefaultLogger is a quick way to get the default logger
+// the same could be done using `main` or `root` as a parameters to `GetLogger`
+func DefaultLogger() (cl interfaces.Log) {
+	return root
+}
+
+// GetLogger provides a way to get any named logger
+// if the name is `main` or `root` then the default loggers is returned
+// any other name generates a new child logger of the default logger
 func GetLogger(name string) (cl interfaces.Log) {
 	if name == rootLoggerName || name == alternateLoggerName {
 		cl = root
@@ -39,6 +57,7 @@ func GetLogger(name string) (cl interfaces.Log) {
 	return
 }
 
+// RemoveLoggers drops a child logger from the instances
 func RemoveLogger(cl interfaces.Log) {
 	if v, ok := root.childLoggers[cl.Name()]; ok {
 		if v.Name() == cl.Name() {

--- a/loggers/init_test.go
+++ b/loggers/init_test.go
@@ -1,0 +1,75 @@
+package loggers
+
+import (
+	"testing"
+
+	"github.com/ClockwerksSoftware/golog/interfaces"
+)
+
+func TestGlobalMethods(t *testing.T) {
+	t.Run(
+		"DefaultLogger",
+		func(t *testing.T) {
+			if root == nil {
+				t.Fatalf("init did not run and initialize the root logger")
+			}
+			dl := DefaultLogger()
+			if dl != root {
+				t.Errorf("Default logger did not return the appropriate logger: %#v != %#v", dl, root)
+			}
+
+			rl := GetLogger(rootLoggerName)
+			ml := GetLogger(alternateLoggerName)
+
+			if rl != root {
+				t.Errorf("%s did not return the root logger: %#v != %#v", rootLoggerName, rl, root) 
+			}
+			if ml != root {
+				t.Errorf("%s did not return the root logger: %#v != %#v", alternateLoggerName, ml, root) 
+			}
+		},
+	)
+	t.Run(
+		"GetLogger",
+		func(t *testing.T) {
+			expectedName := "foobar"
+
+			if len(root.childLoggers) != 0 {
+				t.Errorf("Unexpected existing child loggers: %#v", root.childLoggers)
+			}
+			l := GetLogger(expectedName)
+			if l.Name() != expectedName {
+				t.Errorf("Child logger did not have the expected name: %q != %q", l.Name(), expectedName)
+			}
+			if len(root.childLoggers) != 1 {
+				t.Errorf("Unexpected existing child loggers: %#v", root.childLoggers)
+			}
+			l2 := GetLogger(expectedName)
+			if l2 != l {
+				t.Errorf("Repetitiv call with same name did not yield the same logger: %#v != !%#v", l, l2)
+			}
+			if len(root.childLoggers) != 1 {
+				t.Errorf("Unexpected existing child loggers: %#v", root.childLoggers)
+			}
+
+			// cleanup
+			root.childLoggers = make(map[string]interfaces.Log)
+		},
+	)
+	t.Run(
+		"RemoveLogger",
+		func(t *testing.T) {
+			if len(root.childLoggers) != 0 {
+				t.Errorf("Unexpected existing child loggers: %#v", root.childLoggers)
+			}
+			l := GetLogger(t.Name())
+			if len(root.childLoggers) != 1 {
+				t.Errorf("Unexpected existing child loggers: %#v", root.childLoggers)
+			}
+			RemoveLogger(l)
+			if len(root.childLoggers) != 0 {
+				t.Errorf("Unexpected existing child loggers: %#v", root.childLoggers)
+			}
+		},
+	)
+}

--- a/record/level.go
+++ b/record/level.go
@@ -14,10 +14,10 @@ type LogLevel struct {
 
 const (
 	CRITICAL LogLevelInt = 0
-	DEBUG                = 30
-	ERROR                = 50
-	WARNING              = 70
-	INFO                 = 90
+	DEBUG    LogLevelInt = 30
+	ERROR    LogLevelInt = 50
+	WARNING  LogLevelInt = 70
+	INFO     LogLevelInt = 90
 )
 
 var (

--- a/record/level_test.go
+++ b/record/level_test.go
@@ -38,7 +38,7 @@ func TestLogLevel(t *testing.T) {
 			l := &LogLevel{
 				level: LogLevelInt(desiredLogLevel),
 			}
-			if l.Int() != desiredLogLevel {
+			if l.Int() != int(desiredLogLevel) {
 				t.Logf("Unexpected log level found: %d != %d", l.level, desiredLogLevel)
 			}
 		},

--- a/record/record.go
+++ b/record/record.go
@@ -89,7 +89,7 @@ func (lr *logRecord) AddAttributes(attr ...interfaces.Attribute) {
 			attr_copy,
 			NewLogAttr(
 				v.Key(),
-				deepcopy.MustAnything(v.Value()).(any),
+				deepcopy.MustAnything(v.Value()),
 			),
 		)
 	}


### PR DESCRIPTION
- Bug Fix: handler did not expand arguments properly when formatting
- Enhancement: Use the change the log messages to be the standard unformatted version and then add the `f` version for the formatted version
- Add a MockHandler for testing which captures data to a buffer
- Test Core Logger
- Add a new DefaultLogger method as a shortcut for getting the root logger